### PR TITLE
Config to fix router 404 issues

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,8 @@
+# This config is to prevent Vue Router serving 404 pages
+RewriteEngine On
+RewriteRule ^index\.html$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.html [L]
+
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: 'ehri-dashboard',
+  base: '/',
   plugins: [vue()],
   resolve: {
     alias: {


### PR DESCRIPTION
These two tweaks should fix the Vue Router 404 issues:

 - set `base` to '/', instead of an empty string, meaning assets get loaded via absolute rather than relative paths
 - add a .htaccess config to redirect all paths that don't refer to a static file to the index.html